### PR TITLE
fix github action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,8 +5,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches-ignore:
-      - main
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
on push ignore-branch causes an action to fire for every branch that is not included in that branch.

removing that on push and leaving `on push tag` ensures the release action only runs when tagged.